### PR TITLE
Store should call subscriptions on delete

### DIFF
--- a/store.test.ts
+++ b/store.test.ts
@@ -7,3 +7,14 @@ test("basic set, get, remove", () => {
   store.delete("value");
   expect(store.get("value")).toBeUndefined();
 });
+
+test("listener set, delete", () => {
+  const store = new Store();
+  store.set("value", 1);
+  const listener = jest.fn();
+  store.subscribe("value", listener);
+  store.set("value", 2);
+  expect(listener).toBeCalledWith(2);
+  store.delete("value");
+  expect(listener).toBeCalledWith(null);
+});

--- a/store.test.ts
+++ b/store.test.ts
@@ -16,5 +16,5 @@ test("listener set, delete", () => {
   store.set("value", 2);
   expect(listener).toBeCalledWith(2);
   store.delete("value");
-  expect(listener).toBeCalledWith(null);
+  expect(listener).toBeCalledWith();
 });

--- a/store.ts
+++ b/store.ts
@@ -1,6 +1,6 @@
 export default class Store {
   private data = new Map<string, any>();
-  private subscriptions = new Map<string, ((value: any) => void)[]>();
+  private subscriptions = new Map<string, ((value?: any) => void)[]>();
 
   public get = (key: string, defaultValue?: any) =>
     this.data.get(key) || defaultValue;
@@ -19,11 +19,11 @@ export default class Store {
     const subscriptions = this.subscriptions.get(key);
 
     if (subscriptions) {
-      subscriptions.forEach(fn => fn(null));
+      subscriptions.forEach(fn => fn());
     }
   };
 
-  public subscribe = (key: string, fn: (value: any) => void) => {
+  public subscribe = (key: string, fn: (value?: any) => void) => {
     const subscriptions = this.subscriptions.get(key);
 
     if (subscriptions) {
@@ -35,7 +35,7 @@ export default class Store {
     return () => this.unsubscribe(key, fn);
   };
 
-  private unsubscribe = (key: string, fnToDelete: (value: any) => void) => {
+  private unsubscribe = (key: string, fnToDelete: (value?: any) => void) => {
     const subscriptions = this.subscriptions.get(key);
     this.subscriptions.set(key, subscriptions.filter(fn => fn !== fnToDelete));
   };

--- a/store.ts
+++ b/store.ts
@@ -15,6 +15,12 @@ export default class Store {
   };
   public delete = (key: string) => {
     this.data.delete(key);
+
+    const subscriptions = this.subscriptions.get(key);
+
+    if (subscriptions) {
+      subscriptions.forEach(fn => fn(null));
+    }
   };
 
   public subscribe = (key: string, fn: (value: any) => void) => {


### PR DESCRIPTION
When an entry is deleted listeners should be called too, not only when an entry is set

I wrote some test about listeners